### PR TITLE
Radio buttons for quick edit too

### DIFF
--- a/main.php
+++ b/main.php
@@ -4,14 +4,15 @@ Plugin Name: Only One Category
 Plugin URI: http://pressupinc.com/wordpress-plugins/only-one-category/
 Description: Limits a post to a single category by changing the checkboxes into radio buttons. Simple.
 Author: Press Up
-Version: 1.0.2
+Version: 1.0.3
 Author URI: http://pressupinc.com
-*/ 
+*/
 
 add_action( 'admin_init', 'ooc_admin_catcher' );
 function ooc_admin_catcher() {
-	if ( strstr( $_SERVER['REQUEST_URI'], 'wp-admin/post-new.php' ) 
-		|| strstr( $_SERVER['REQUEST_URI'], 'wp-admin/post.php' ) ) {
+	if ( strstr( $_SERVER['REQUEST_URI'], 'wp-admin/post-new.php' )
+		|| strstr( $_SERVER['REQUEST_URI'], 'wp-admin/post.php' )
+		|| strstr( $_SERVER['REQUEST_URI'], 'wp-admin/edit.php' )) {
 		ob_start( 'ooc_swap_out_checkboxes' );
 		ob_flush();
 	}
@@ -22,7 +23,7 @@ function ooc_swap_out_checkboxes($content) {
 
 	// for "Most Used" tab
 	$categories = get_terms( 'category' );
-	
+
 	foreach ($categories as $i) {
 		$content = str_replace( 'id="in-popular-category-'.$i->term_id.'" type="checkbox"', 'id="in-popular-category-'.$i->term_id.'" type="radio"', $content );
 	}


### PR DESCRIPTION
On the post list admin screen, you can “quick edit” a post’s categories
without loading the post’s edit page. However, the plugin doesn’t yet
swap out the checkboxes in this context. This fork swaps them in this context too.
