### PR TITLE
Radio buttons for quick edit too

### DIFF
--- a/js/inline-edit.js
+++ b/js/inline-edit.js
@@ -34,8 +34,6 @@
 				var taxname,
 					term_ids = $(this).text();
 
-				// window.alert(term_ids);
-
 				if ( term_ids ) {
 					taxname = $(this).attr('id').replace('_'+id, '');
 					$('ul.cat-checklist :radio', $edit_row).val(term_ids.split(','));

--- a/js/inline-edit.js
+++ b/js/inline-edit.js
@@ -1,0 +1,49 @@
+/*
+ * This script populates the radio button with the checked category
+ * on the Quick Edit form in edit.php
+ * https://codex.wordpress.org/Plugin_API/Action_Reference/quick_edit_custom_box
+ */
+
+(function($) {
+
+	// we create a copy of the WP inline edit post function
+	var $wp_inline_edit = inlineEditPost.edit;
+
+	// and then we overwrite the function with our own code
+	inlineEditPost.edit = function( id ) {
+
+		// "call" the original WP edit function
+		// we don't want to leave WordPress hanging
+		$wp_inline_edit.apply( this, arguments );
+
+		// now we take care of our business
+
+		// get the post ID
+		var $post_id = 0;
+		if ( typeof( id ) == 'object' ) {
+			$post_id = parseInt( this.getId( id ) );
+		}
+
+		if ( $post_id > 0 ) {
+			// define the edit row
+			var $edit_row = $( '#edit-' + $post_id );
+			var $post_row = $( '#post-' + $post_id );
+
+			// hierarchical taxonomies
+			$('.post_category', $post_row).each(function(){
+				var taxname,
+					term_ids = $(this).text();
+
+				// window.alert(term_ids);
+
+				if ( term_ids ) {
+					taxname = $(this).attr('id').replace('_'+id, '');
+					$('ul.cat-checklist :radio', $edit_row).val(term_ids.split(','));
+				}
+			});
+
+		}
+
+	};
+
+})(jQuery);

--- a/main.php
+++ b/main.php
@@ -4,14 +4,15 @@ Plugin Name: Only One Category
 Plugin URI: http://pressupinc.com/wordpress-plugins/only-one-category/
 Description: Limits a post to a single category by changing the checkboxes into radio buttons. Simple.
 Author: Press Up
-Version: 1.0.2
+Version: 1.0.3
 Author URI: http://pressupinc.com
-*/ 
+*/
 
 add_action( 'admin_init', 'ooc_admin_catcher' );
 function ooc_admin_catcher() {
-	if ( strstr( $_SERVER['REQUEST_URI'], 'wp-admin/post-new.php' ) 
-		|| strstr( $_SERVER['REQUEST_URI'], 'wp-admin/post.php' ) ) {
+	if ( strstr( $_SERVER['REQUEST_URI'], 'wp-admin/post-new.php' )
+		|| strstr( $_SERVER['REQUEST_URI'], 'wp-admin/post.php' )
+		|| strstr( $_SERVER['REQUEST_URI'], 'wp-admin/edit.php' )) {
 		ob_start( 'ooc_swap_out_checkboxes' );
 		ob_flush();
 	}
@@ -22,7 +23,7 @@ function ooc_swap_out_checkboxes($content) {
 
 	// for "Most Used" tab
 	$categories = get_terms( 'category' );
-	
+
 	foreach ($categories as $i) {
 		$content = str_replace( 'id="in-popular-category-'.$i->term_id.'" type="checkbox"', 'id="in-popular-category-'.$i->term_id.'" type="radio"', $content );
 	}

--- a/main.php
+++ b/main.php
@@ -30,3 +30,18 @@ function ooc_swap_out_checkboxes($content) {
 
 	return $content;
 }
+
+/* load script in the footer */
+if ( ! function_exists('ooc_admin_enqueue_scripts') ):
+function ooc_admin_enqueue_scripts( $hook ) {
+
+	if ( 'edit.php' === $hook ) {
+
+		wp_enqueue_script( 'ooc_inline_edit_script', plugins_url('js/inline-edit.js', __FILE__),
+			false, null, true );
+
+	}
+
+}
+endif;
+add_action( 'admin_enqueue_scripts', 'ooc_admin_enqueue_scripts' );


### PR DESCRIPTION
On the post list admin screen, you can “quick edit” a post’s categories
without loading the post’s edit page. However, the plugin doesn’t yet
swap out the checkboxes in this context. This fork swaps the checkbox
for radio buttons in this context too. It contains a small script to populate the radio buttons with the checked category, if any.
